### PR TITLE
fix output charts, if --charts-from AND --charts-from is set

### DIFF
--- a/jira_cycle_extract/cli.py
+++ b/jira_cycle_extract/cli.py
@@ -229,7 +229,7 @@ def main():
         if charts_from is not None:
             cycle_data_sliced = cycle_data[cycle_data['completed_timestamp'] >= charts_from]
         if charts_to is not None:
-            cycle_data_sliced = cycle_data[cycle_data['completed_timestamp'] <= charts_to]
+            cycle_data_sliced = cycle_data_sliced[cycle_data_sliced['completed_timestamp'] <= charts_to]
         
         cfd_data_sliced = cfd_data[slice(charts_from, charts_to)]
         


### PR DESCRIPTION
The "--charts-to" parameter overrides "--charts-from" parameter. Therefor it was not possible to slice the jira data from both ends.
