### PR TITLE
Max results 50

### DIFF
--- a/jira_cycle_extract/query.py
+++ b/jira_cycle_extract/query.py
@@ -201,11 +201,6 @@ class QueryManager(object):
             print colored("query error with: {}\n{}".format(queryString,e), 'red')
             return []
 
-
-        
-        
-        assert(len(issues) == total_num_issues, "{} issues retrieved: expecting {}".format(len(issues),total_num_issues));
-
         if verbose:
             print "Fetched", len(issues), "issues"
 


### PR DESCRIPTION
Per issue #4, There was an issue (at least with my version of JIRA) that it would give up after pulling 50 issues.  This now iterates to pull them all.